### PR TITLE
Add stub implementations for unsupported (host) targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,23 +288,8 @@ semihosting = { version = "0.1", features = ["stdio", "panic-handler"] }
 
 // 64-bit architecture's 32-bit ABI (e.g., AArch64 ILP32 ABI) are also
 // unsupported yet (is there a semihosting interface defined for those ABIs?).
-#[cfg(not(any(
-    all(target_arch = "aarch64", target_pointer_width = "64"),
-    target_arch = "arm",
-    target_arch = "riscv32",
-    all(target_arch = "riscv64", target_pointer_width = "64"),
-    target_arch = "loongarch32",
-    all(target_arch = "loongarch64", target_pointer_width = "64"),
-    target_arch = "mips",
-    target_arch = "mips32r6",
-    all(target_arch = "mips64", target_pointer_width = "64"),
-    all(target_arch = "mips64r6", target_pointer_width = "64"),
-    target_arch = "xtensa",
-)))]
-compile_error!(
-    "unsupported target; if you need support for this target, \
-     please submit an issue at <https://github.com/taiki-e/semihosting>"
-);
+// On unsupported targets the crate still compiles but all semihosting calls
+// panic at runtime.
 #[cfg(target_arch = "xtensa")]
 #[cfg(not(feature = "openocd-semihosting"))]
 compile_error!(

--- a/src/sys/env.rs
+++ b/src/sys/env.rs
@@ -1,5 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![cfg_attr(
+    not(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch32",
+        target_arch = "loongarch64",
+        target_arch = "xtensa",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+    )),
+    allow(dead_code)
+)]
+
 use core::{cell::Cell, mem::MaybeUninit};
 
 use crate::{io, utils::slice_assume_init_ref};

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -77,6 +77,26 @@ use self::mips as arch;
 )]
 pub mod mips;
 
+cfg_sel!({
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch32",
+        target_arch = "loongarch64",
+        target_arch = "xtensa",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+    )))]
+    {
+        use self::unsupported as arch;
+        mod unsupported;
+    }
+});
+
 #[cfg(feature = "args")]
 pub(crate) mod env;
 mod errno;

--- a/src/sys/reg.rs
+++ b/src/sys/reg.rs
@@ -1,6 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![allow(missing_docs)]
+#![cfg_attr(
+    not(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch32",
+        target_arch = "loongarch64",
+        target_arch = "xtensa",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+    )),
+    allow(dead_code, unreachable_pub)
+)]
 
 use core::{
     ffi::{CStr, c_int, c_void},

--- a/src/sys/unsupported/errno.rs
+++ b/src/sys/unsupported/errno.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![allow(dead_code)]
+
+use core::ffi::c_int;
+
+pub(crate) const EPERM: c_int = 1;
+pub(crate) const ENOENT: c_int = 2;
+pub(crate) const ESRCH: c_int = 3;
+pub(crate) const EINTR: c_int = 4;
+pub(crate) const EIO: c_int = 5;
+pub(crate) const ENXIO: c_int = 6;
+pub(crate) const E2BIG: c_int = 7;
+pub(crate) const ENOEXEC: c_int = 8;
+pub(crate) const EBADF: c_int = 9;
+pub(crate) const ECHILD: c_int = 10;
+pub(crate) const ENOMEM: c_int = 12;
+pub(crate) const EACCES: c_int = 13;
+pub(crate) const EFAULT: c_int = 14;
+pub(crate) const EBUSY: c_int = 16;
+pub(crate) const EEXIST: c_int = 17;
+pub(crate) const EXDEV: c_int = 18;
+pub(crate) const ENODEV: c_int = 19;
+pub(crate) const ENOTDIR: c_int = 20;
+pub(crate) const EISDIR: c_int = 21;
+pub(crate) const EINVAL: c_int = 22;
+pub(crate) const ENFILE: c_int = 23;
+pub(crate) const EMFILE: c_int = 24;
+pub(crate) const ENOTTY: c_int = 25;
+pub(crate) const EFBIG: c_int = 27;
+pub(crate) const ENOSPC: c_int = 28;
+pub(crate) const ESPIPE: c_int = 29;
+pub(crate) const EROFS: c_int = 30;
+pub(crate) const EMLINK: c_int = 31;
+pub(crate) const EPIPE: c_int = 32;
+pub(crate) const EDOM: c_int = 33;
+pub(crate) const ERANGE: c_int = 34;
+pub(crate) const EAGAIN: c_int = 11;
+pub(crate) const EWOULDBLOCK: c_int = 11;
+pub(crate) const ETXTBSY: c_int = 26;
+pub(crate) const ENAMETOOLONG: c_int = 36;
+pub(crate) const ELOOP: c_int = 40;
+pub(crate) const ECONNRESET: c_int = 104;
+pub(crate) const ENETUNREACH: c_int = 101;
+pub(crate) const ENETDOWN: c_int = 100;
+pub(crate) const ETIMEDOUT: c_int = 110;
+pub(crate) const ENOTCONN: c_int = 107;

--- a/src/sys/unsupported/fs.rs
+++ b/src/sys/unsupported/fs.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::ffi::CStr;
+
+use crate::{
+    fd::{BorrowedFd, OwnedFd},
+    fs, io,
+};
+
+pub(crate) struct Metadata {
+    _private: (),
+}
+
+impl Metadata {
+    #[inline]
+    #[allow(clippy::unused_self)]
+    pub(crate) fn size(&self) -> u64 {
+        0
+    }
+}
+
+pub(crate) fn metadata(_fd: BorrowedFd<'_>) -> io::Result<Metadata> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn open(_path: &CStr, _options: &fs::OpenOptions) -> io::Result<OwnedFd> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn seek(_fd: BorrowedFd<'_>, _pos: io::SeekFrom) -> io::Result<u64> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn unlink(_path: &CStr) -> io::Result<()> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn rename(_from: &CStr, _to: &CStr) -> io::Result<()> {
+    unimplemented!("semihosting is not available on this target")
+}

--- a/src/sys/unsupported/mod.rs
+++ b/src/sys/unsupported/mod.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Stub implementations for unsupported host targets.
+//!
+//! All functions panic at runtime. This module exists only so that the crate
+//! compiles on non-semihosting targets (e.g., x86_64) for use in tests,
+//! proc-macro crates, or build scripts that depend on types from this crate.
+
+pub(crate) mod errno;
+#[cfg(feature = "fs")]
+pub(crate) mod fs;
+#[cfg(feature = "stdio")]
+pub(crate) mod stdio;
+
+use core::mem::MaybeUninit;
+
+use crate::{
+    fd::{BorrowedFd, RawFd},
+    io,
+};
+
+pub(crate) fn exit(_code: i32) -> ! {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) unsafe fn close(_fd: RawFd) -> io::Result<()> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn read(_fd: BorrowedFd<'_>, _buf: &mut [u8]) -> io::Result<usize> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn read_uninit<'a>(
+    _fd: BorrowedFd<'_>,
+    _buf: &'a mut [MaybeUninit<u8>],
+) -> io::Result<(&'a mut [u8], &'a mut [MaybeUninit<u8>])> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+pub(crate) fn write(_fd: BorrowedFd<'_>, _buf: &[u8]) -> io::Result<usize> {
+    unimplemented!("semihosting is not available on this target")
+}

--- a/src/sys/unsupported/stdio.rs
+++ b/src/sys/unsupported/stdio.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::{
+    fd::{BorrowedFd, OwnedFd},
+    io,
+};
+
+pub(crate) type StdioFd = OwnedFd;
+
+pub(crate) fn stdin() -> io::Result<StdioFd> {
+    unimplemented!("semihosting is not available on this target")
+}
+pub(crate) fn stdout() -> io::Result<StdioFd> {
+    unimplemented!("semihosting is not available on this target")
+}
+pub(crate) fn stderr() -> io::Result<StdioFd> {
+    unimplemented!("semihosting is not available on this target")
+}
+
+#[inline]
+pub(crate) fn should_close(_fd: &OwnedFd) -> bool {
+    true
+}
+
+pub(crate) fn is_terminal(_fd: BorrowedFd<'_>) -> bool {
+    false
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,6 +45,7 @@ pub(crate) const unsafe fn slice_assume_init_ref<T>(s: &[MaybeUninit<T>]) -> &[T
 /// behavior: it is up to the caller to guarantee that every `MaybeUninit<T>` in the
 /// slice really is in an initialized state. For instance, `.assume_init_mut()` cannot
 /// be used to initialize a `MaybeUninit` slice.
+#[allow(dead_code)]
 #[inline(always)]
 pub(crate) unsafe fn slice_assume_init_mut<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
     // SAFETY: similar to safety notes for `slice_get_ref`, but we have a

--- a/tests/no-std-rt/Cargo.toml
+++ b/tests/no-std-rt/Cargo.toml
@@ -49,21 +49,21 @@ aarch32-rt = { optional = true, git = "https://github.com/taiki-e/aarch32.git", 
 aarch32-rt = { optional = true, git = "https://github.com/taiki-e/aarch32.git", rev = "8b1e01f356a2cf31616061607f5f0d3e00a147cf" }
 # Armv6-M
 [target.thumbv6m-none-eabi.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 # Armv7-M
 [target.thumbv7m-none-eabi.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 [target.thumbv7em-none-eabi.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 [target.thumbv7em-none-eabihf.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 # Armv8-M
 [target.'thumbv8m.base-none-eabi'.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 [target.'thumbv8m.main-none-eabi'.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 [target.'thumbv8m.main-none-eabihf'.dependencies]
-cortex-m-rt = { optional = true, version = "0.7" }
+cortex-m-rt = { optional = true, version = "=0.7.0" }
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
Allow the crate to compile on non-semihosting architectures (e.g., x86_64) by providing panic-at-runtime stubs instead of a compile_error. This enables projects that target embedded platforms to run cargo check, clippy, and rust-analyzer against the host without cross-compilation.

Issue: #31